### PR TITLE
fix reference to anthropic lib version

### DIFF
--- a/prosaic_kernel/kernel.py
+++ b/prosaic_kernel/kernel.py
@@ -41,7 +41,7 @@ class MetaKernelProsaic(MetaKernel):
     implementation_version = __version__
     
     language = 'markdown'
-    language_version = anthropic.ANTHROPIC_CLIENT_VERSION
+    language_version = anthropic.__version__
 
     banner = "Prosaic kernel - ask and we shall answer" #REVIEW
     language_info = {'name': 'prosaic',


### PR DESCRIPTION
Currently installation fails with `AttributeError: module 'anthropic' has no attribute 'ANTHROPIC_CLIENT_VERSION'` because `anthropic` has changed where it keeps the lib version.

One-liner fixes this, now installs cleanly.